### PR TITLE
feat(#6): as-phi atom

### DIFF
--- a/eo2js-runtime/src/objects/org/eolang/as-phi.js
+++ b/eo2js-runtime/src/objects/org/eolang/as-phi.js
@@ -1,19 +1,18 @@
 const object = require('../../../runtime/object')
 const {LAMBDA} = require('../../../runtime/attribute/specials');
-const ErFailure = require('../../../runtime/error/ErFailure');
+const at_void = require('../../../runtime/attribute/at-void');
+const {data} = require('../../../runtime/data');
 
 /**
  * As_phi.
  * @return {Object} - As_phi object
- * @todo #3:30min Implement as_phi atom. We need to implement the atom and make sure it
- *  works. For the details of implementation check the Java analogue on
- *  https://github.com/objectionary/eo/tree/master/eo-runtime/src/main/java/EOorg/EOeolang
  */
 const as_phi = function() {
   const obj = object('as_phi')
-  obj.assets[LAMBDA] = function(_) {
-    throw new ErFailure(
-      `Atom as_phi is not implemented yet`
+  obj.attrs['x'] = at_void('x')
+  obj.assets[LAMBDA] = function(self) {
+    return data.toObject(
+      self.take('x').φTerm()
     )
   }
   return obj

--- a/eo2js-runtime/src/runtime/attribute/at-lambda.js
+++ b/eo2js-runtime/src/runtime/attribute/at-lambda.js
@@ -18,6 +18,9 @@ const at_lambda = function(object, callback) {
     },
     copy: function(rho) {
       return at_lambda(rho, callback)
+    },
+    φTerm: function() {
+      return LAMBDA
     }
   }
 }

--- a/eo2js-runtime/src/runtime/attribute/at-once.js
+++ b/eo2js-runtime/src/runtime/attribute/at-once.js
@@ -5,19 +5,28 @@
  * @return {Object} - Attribute
  */
 const at_once = function(origin) {
-  let cache = null
+  const cache = {
+    object: null,
+    term: null
+  }
   return {
     put: function(object) {
       origin.put(object)
     },
     get: function() {
-      if (cache == null) {
-        cache = origin.get()
+      if (cache.object === null) {
+        cache.object = origin.get()
       }
-      return cache
+      return cache.object
     },
     copy: function(rho) {
       return at_once(origin.copy(rho))
+    },
+    φTerm: function() {
+      if (cache.term === null) {
+        cache.term = origin.φTerm()
+      }
+      return cache.term
     }
   }
 }

--- a/eo2js-runtime/src/runtime/attribute/at-rho.js
+++ b/eo2js-runtime/src/runtime/attribute/at-rho.js
@@ -1,5 +1,7 @@
 const ErFailure = require('../error/ErFailure');
 const {RHO} = require('./specials');
+const at_term = require('./at-term');
+
 /**
  * Attribute that keeps \rho.
  * @param {Object} [object] - Rho object
@@ -7,7 +9,7 @@ const {RHO} = require('./specials');
  */
 const at_rho = function(object = null) {
   let rho = object
-  return {
+  return at_term({
     put: function(obj) {
       if (rho == null) {
         rho = obj
@@ -22,7 +24,7 @@ const at_rho = function(object = null) {
     copy: function(_) {
       return at_rho(rho)
     }
-  }
+  })
 }
 
 module.exports = at_rho

--- a/eo2js-runtime/src/runtime/attribute/at-safe.js
+++ b/eo2js-runtime/src/runtime/attribute/at-safe.js
@@ -1,5 +1,6 @@
 const validated = require('../validated');
 const safe = require('../safe');
+const at_term = require('./at-term');
 
 /**
  * Attribute that catches {@link ErFailure} and throws {@link ErError}.
@@ -7,9 +8,9 @@ const safe = require('../safe');
  * @return {Object} - Attribute
  */
 const at_safe = function(origin) {
-  return {
+  return at_term({
     put: function(object) {
-      return origin.put(object)
+      origin.put(object)
     },
     get: function() {
       return validated(() => safe(origin.get()))
@@ -17,7 +18,7 @@ const at_safe = function(origin) {
     copy: function(rho) {
       return at_safe(origin.copy(rho))
     }
-  }
+  })
 }
 
 module.exports = at_safe

--- a/eo2js-runtime/src/runtime/attribute/at-term.js
+++ b/eo2js-runtime/src/runtime/attribute/at-term.js
@@ -1,0 +1,15 @@
+/**
+ * Attribute as φTerm.
+ * @param {Object} origin - Original attribute
+ * @return {Object} - Attribute with default φTerm
+ */
+const at_term = function(origin) {
+  return {
+    ...origin,
+    φTerm: function() {
+      return origin.get().φTerm()
+    }
+  }
+}
+
+module.exports = at_term

--- a/eo2js-runtime/src/runtime/attribute/at-void.js
+++ b/eo2js-runtime/src/runtime/attribute/at-void.js
@@ -1,4 +1,5 @@
 const ErFailure = require('../error/ErFailure');
+const {EMPTY} = require('./specials');
 
 /**
  * Void attribute.
@@ -14,7 +15,6 @@ const at_void = function(name, object = null) {
         throw new ErFailure(`Void attribute '${name}' is already set, can't reset`)
       }
       obj = object
-      return true
     },
     get: function() {
       if (obj == null) {
@@ -24,6 +24,15 @@ const at_void = function(name, object = null) {
     },
     copy: function(_) {
       return at_void(name, obj)
+    },
+    φTerm: function() {
+      let term
+      if (obj === null) {
+        term = EMPTY
+      } else {
+        term = obj.φTerm()
+      }
+      return term
     }
   }
 }

--- a/eo2js-runtime/src/runtime/attribute/specials.js
+++ b/eo2js-runtime/src/runtime/attribute/specials.js
@@ -1,10 +1,11 @@
 /**
  * Attribute and asset names.
- * @type {{PHI: string, DELTA: string, SIGMA: string, RHO: string, VTX: string, LAMBDA: string}}
+ * @type {{PHI: string, DELTA: string, SIGMA: string, RHO: string, VTX: string, LAMBDA: string, EMPTY: string}}
  */
 module.exports = {
   PHI: 'φ',
   DELTA: 'Δ',
   LAMBDA: 'λ',
   RHO: 'ρ',
+  EMPTY: 'Ø'
 }

--- a/eo2js-runtime/src/runtime/object.js
+++ b/eo2js-runtime/src/runtime/object.js
@@ -149,6 +149,30 @@ const object = function(name = 'object') {
      */
     forma: function() {
       return name
+    },
+    /**
+     * Represent self as φ term.
+     * @return {String} - Self as φ calculus term
+     */
+    φTerm: function() {
+      const list = []
+      const binding = (left, right) => `${left} ↦ ${right}`
+      if (this.assets.hasOwnProperty(DELTA)) {
+        list.push(binding(DELTA, `[${this.assets[DELTA].join(', ')}]`))
+      }
+      if (this.assets.hasOwnProperty(LAMBDA)) {
+        list.push(binding(LAMBDA, 'Lambda'))
+      }
+      list.push(
+        ...Object.keys(this.attrs)
+          .filter((attr) => attr !== RHO)
+          .map((attr) => binding(attr, this.attrs[attr].φTerm()))
+      )
+      let term = name
+      if (list.length !== 0) {
+        term = `ν${vtx}·${term}⟦\n\t${list.sort().join(',\n').replaceAll(/\n/g, '\n\t')}\n⟧`
+      }
+      return term
     }
   }
 }

--- a/eo2js-runtime/test/runtime/object.test.js
+++ b/eo2js-runtime/test/runtime/object.test.js
@@ -198,4 +198,22 @@ describe('object', function() {
       assert.deepStrictEqual(obj.assets, copy.assets)
     })
   })
+  describe('#φTerm()', function() {
+    it('should contain all properties', function() {
+      const somebody = object('somebody')
+      somebody.attrs['m'] = at_void('m')
+      const obj = object('x')
+      obj.attrs['y'] = at_void('y')
+      obj.attrs['s'] = at_simple(somebody)
+      obj.assets[DELTA] = [1, 2, 3]
+      obj.assets[LAMBDA] = () => {}
+      const term = obj.φTerm()
+      console.debug(term)
+      assert.ok(term.includes('·x⟦'))
+      assert.ok(term.includes('Δ ↦ [1, 2, 3],'))
+      assert.ok(term.includes('λ ↦ Lambda'))
+      assert.ok(term.includes('s ↦ λ,'))
+      assert.ok(term.includes('y ↦ Ø,'))
+    })
+  })
 })

--- a/eo2js/test/it/runtime-tests.test.js
+++ b/eo2js/test/it/runtime-tests.test.js
@@ -13,7 +13,6 @@ const assert = require('assert');
  * @type {string[]}
  */
 const exclude = [
-  'as-phi-tests',
   'rust-tests',
 ].map((name) => `org/eolang/${name}.test.js`)
 


### PR DESCRIPTION
Closes: #6 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces changes related to the implementation of φ terms in the runtime module.

### Detailed summary
- Added `φTerm` method to `at-term` and `at-void` attributes
- Updated `specials` with `EMPTY` constant
- Modified object representation with `φTerm` method
- Implemented `as_phi` object with `at-void` attribute

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->