### PR TITLE
fix(#79): fixed meta finding

### DIFF
--- a/eo2js/src/commands/transpile.js
+++ b/eo2js/src/commands/transpile.js
@@ -47,13 +47,11 @@ const makeDirIfNotExist = function(dir) {
  */
 const hasMeta = function(xmir, name) {
   const metas = xmir.program.metas.meta
-  let res
+  let res = false
   if (Array.isArray(metas)) {
     res = metas.findIndex((meta) => meta.head === name) !== -1
   } else if (typeof metas === 'object' && metas.hasOwnProperty('head')) {
     res = metas.head === name
-  } else {
-    throw new Error(`Unexpected type ${typeof metas} of metas in given XMIR:\n${xmir}`)
   }
   return res
 }

--- a/eo2js/src/commands/transpile.js
+++ b/eo2js/src/commands/transpile.js
@@ -47,7 +47,15 @@ const makeDirIfNotExist = function(dir) {
  */
 const hasMeta = function(xmir, name) {
   const metas = xmir.program.metas.meta
-  return Array.isArray(metas) && metas.findIndex((meta) => meta.head === name) !== -1
+  let res
+  if (Array.isArray(metas)) {
+    res = metas.findIndex((meta) => meta.head === name) !== -1
+  } else if (typeof metas === 'object' && metas.hasOwnProperty('head')) {
+    res = metas.head === name
+  } else {
+    throw new Error(`Unexpected type ${typeof metas} of metas in given XMIR:\n${xmir}`)
+  }
+  return res
 }
 
 /**

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -62,9 +62,11 @@ describe('transpile', function() {
     })
     it('should generate JS files', function() {
       assertFilesExist(transpile(), target, ['project/com/eo2js/simple.js'])
-    })
-    it('should generate test JS file', function() {
-      assertFilesExist(transpile('simple-test'), target, ['project/com/eo2js/simple-test.test.js'])
+    });
+    ['simple-test', 'alone-test'].forEach((name) => {
+      it(`should generate test JS file for ${name}`, function() {
+        assertFilesExist(transpile(name), target, [`project/com/eo2js/${name}.test.js`])
+      })
     })
   })
   describe('transformation packs', function() {

--- a/eo2js/test/resources/transpile/alone-test.xmir
+++ b/eo2js/test/resources/transpile/alone-test.xmir
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-02-13T11:50:46"
+         ms="49"
+         name="com.eo2js.alone-test"
+         revision="33bb3b6"
+         source="/Users/maxonfjvipon/code/javascript/eo2js/eo2js/temp/test-transpile/src/org/eolang/alone-test.eo"
+         time="2024-03-01T18:04:33.829973Z"
+         version="0.35.2"><!--This is XMIR - a dialect of XML, which is used to present a parsed EO program. For more information please visit https://news.eolang.org/2022-11-25-xmir-guide.html-->
+   <listing>+tests
++package com.eo2js
+
+# This is the default 64+ symbols comment in front of named abstract object.
+[] &gt; alone-test
+</listing>
+   <errors>
+      <error check="missing-package"
+             line=""
+             severity="warning"
+             sheet="mandatory-package-meta"
+             step="0">Missing package</error>
+      <error check="missing-home"
+             line=""
+             severity="warning"
+             sheet="mandatory-home-meta"
+             step="0">Missing home</error>
+      <error check="missing-version-meta"
+             line=""
+             severity="warning"
+             sheet="mandatory-version-meta"
+             step="0">Missing version meta</error>
+      <error check="unit-test-without-phi"
+             line="4"
+             severity="warning"
+             sheet="unit-test-without-phi"
+             step="0">Unit test without '@': "transpile"</error>
+   </errors>
+   <sheets>
+      <sheet>stars-to-tuples</sheet>
+      <sheet>not-empty-atoms</sheet>
+      <sheet>duplicate-names</sheet>
+      <sheet>many-free-attributes</sheet>
+      <sheet>broken-aliases</sheet>
+      <sheet>duplicate-aliases</sheet>
+      <sheet>global-nonames</sheet>
+      <sheet>same-line-names</sheet>
+      <sheet>self-naming</sheet>
+      <sheet>cti-adds-errors</sheet>
+      <sheet>add-refs</sheet>
+      <sheet>wrap-method-calls</sheet>
+      <sheet>expand-qqs</sheet>
+      <sheet>add-probes</sheet>
+      <sheet>vars-float-up</sheet>
+      <sheet>add-refs</sheet>
+      <sheet>sparse-decoration</sheet>
+      <sheet>unsorted-metas</sheet>
+      <sheet>incorrect-architect</sheet>
+      <sheet>incorrect-home</sheet>
+      <sheet>incorrect-version</sheet>
+      <sheet>expand-aliases</sheet>
+      <sheet>resolve-aliases</sheet>
+      <sheet>add-refs</sheet>
+      <sheet>add-default-package</sheet>
+      <sheet>broken-refs</sheet>
+      <sheet>unknown-names</sheet>
+      <sheet>noname-attributes</sheet>
+      <sheet>duplicate-names</sheet>
+      <sheet>duplicate-metas</sheet>
+      <sheet>mandatory-package-meta</sheet>
+      <sheet>mandatory-home-meta</sheet>
+      <sheet>mandatory-version-meta</sheet>
+      <sheet>correct-package-meta</sheet>
+      <sheet>prohibited-package</sheet>
+      <sheet>external-weak-typed-atoms</sheet>
+      <sheet>unused-aliases</sheet>
+      <sheet>unit-test-without-phi</sheet>
+      <sheet>explicit-data</sheet>
+      <sheet>const-to-dataized</sheet>
+      <sheet>set-locators</sheet>
+   </sheets>
+   <license/>
+   <metas>
+      <meta line="1">
+         <head>tests</head>
+         <tail/>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract=""
+         line="3"
+         loc="Φ.alone-test"
+         name="alone-test"
+         original-name="alone-test"
+         pos="0"/>
+   </objects>
+</program>


### PR DESCRIPTION
Closes: #79

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `transpile` function to handle different types of meta objects and adds test generation for multiple files.

### Detailed summary
- Improved `hasMeta` function to handle different meta object types
- Added test generation for `simple-test` and `alone-test`
- Updated XMIR file for `alone-test` with additional metadata and errors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->