### PR TITLE
Transpilation Optimization

### DIFF
--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -83,7 +83,7 @@ describe('transpile', function() {
       transpile()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const firstModified = fs.statSync(transpiled).mtime
-      const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+      const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
       wait(100);
       transpile()
       const secondModified = fs.statSync(transpiled).mtime

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -38,6 +38,7 @@ describe('transpile', function() {
     /**
      * Call transpile command.
      * @param {String} name - Name of the object to transpile
+     * @param {boolean} copyVerifiedFile - Whether to copy the verified XMIR file
      * @return {String} - Stdout
      */
     const transpile = function(name = 'simple', copyVerifiedFile = true) {

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -96,10 +96,11 @@ describe('transpile', function() {
       assert.equal(first.getTime(), second.getTime())
     })
     it('should retranspile if source was modified', async function() {
+      transpile()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const source = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
-      transpile()
       const first = fs.statSync(transpiled).mtime
+      await new Promise(resolve => setTimeout(resolve, 1000))
       fs.writeFileSync(source, fs.readFileSync(source))
       retranspile()
       const second = fs.statSync(transpiled).mtime

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -79,12 +79,14 @@ describe('transpile', function() {
       const secondModifiedTime = fs.statSync(transpiled).mtime
       assert.equal(firstModifiedTime.getTime(), secondModifiedTime.getTime())
     })
-    it('should retranspile if source was modified', function() {
+    it('should retranspile if source was modified', async function() {
       transpile()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const firstModified = fs.statSync(transpiled).mtime
       const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-      wait(100);
+      await wait(100);
+      const source = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
+      fs.utimesSync(source, new Date(), new Date()) // Touch source file to update mtime
       transpile()
       const secondModified = fs.statSync(transpiled).mtime
       assert.notEqual(firstModified.getTime(), secondModified.getTime())

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -84,9 +84,9 @@ describe('transpile', function() {
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const firstModified = fs.statSync(transpiled).mtime
       const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-      await wait(100);
+      await wait(1200);
       const source = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
-      fs.utimesSync(source, new Date(), new Date()) // Touch source file to update mtime
+      fs.utimesSync(source, new Date(), new Date())
       transpile()
       const secondModified = fs.statSync(transpiled).mtime
       assert.notEqual(firstModified.getTime(), secondModified.getTime())

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -86,7 +86,7 @@ describe('transpile', function() {
       const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
       await wait(1200);
       const source = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
-      fs.utimesSync(source, new Date(), new Date())
+      fs.writeFileSync(source, fs.readFileSync(source))
       transpile()
       const secondModified = fs.statSync(transpiled).mtime
       assert.notEqual(firstModified.getTime(), secondModified.getTime())

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -79,7 +79,7 @@ describe('transpile', function() {
       })
     })
     it('should skip transpilation if source was not modified', function() {
-      prepare('simple')
+      prepare()
       transpile()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const first = fs.statSync(transpiled).mtime

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -100,7 +100,7 @@ describe('transpile', function() {
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const source = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
       const first = fs.statSync(transpiled).mtime
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await new Promise((resolve) => setTimeout(resolve, 1000))
       fs.writeFileSync(source, fs.readFileSync(source))
       retranspile()
       const second = fs.statSync(transpiled).mtime

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -83,6 +83,8 @@ describe('transpile', function() {
       transpile()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const firstModified = fs.statSync(transpiled).mtime
+      const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+      wait(100);
       transpile()
       const secondModified = fs.statSync(transpiled).mtime
       assert.notEqual(firstModified.getTime(), secondModified.getTime())

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -26,6 +26,7 @@ describe('transpile', function() {
     beforeEach(function() {
       fs.rmSync(target, {recursive: true, force: true})
       fs.mkdirSync(target)
+      prepare()
     })
     it('should fail if eo-foreign is not found', function() {
       assert.throws(() => runSync(['transpile', '-t', target], false))
@@ -64,12 +65,10 @@ describe('transpile', function() {
     }
     it('should create transpiled XMIRs', function() {
       const traspiled = '8-transpile/com/eo2js/simple.xmir'
-      prepare()
       assertFilesExist(transpile(), target, [traspiled])
       assert.ok(fs.readFileSync(path.resolve(target, traspiled)).toString().includes('<javascript'))
     })
     it('should generate JS files', function() {
-      prepare()
       assertFilesExist(transpile(), target, ['project/com/eo2js/simple.js'])
     });
     ['simple-test', 'alone-test'].forEach((name) => {
@@ -79,7 +78,6 @@ describe('transpile', function() {
       })
     })
     it('should skip transpilation if source was not modified', function() {
-      prepare()
       transpile()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const first = fs.statSync(transpiled).mtime
@@ -88,7 +86,6 @@ describe('transpile', function() {
       assert.equal(first.getTime(), second.getTime())
     })
     it('should retranspile if source was modified', async function() {
-      prepare()
       const transpiled = path.resolve(target, '8-transpile/com/eo2js/simple.xmir')
       const source = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
       transpile()

--- a/eo2js/test/commands/transpile.test.js
+++ b/eo2js/test/commands/transpile.test.js
@@ -68,6 +68,20 @@ describe('transpile', function() {
         assertFilesExist(transpile(name), target, [`project/com/eo2js/${name}.test.js`])
       })
     })
+    it('should skip transpilation if source was not modified', function() {
+      const output1 = transpile()
+      assert.ok(output1.includes('Skipping') === false)
+      const output2 = transpile() 
+      assert.ok(output2.includes('Skipping'))
+    })
+    it('should retranspile if source was modified', function() {
+      transpile()
+      const verified = path.resolve(target, '6-verify/com/eo2js/simple.xmir')
+      const content = fs.readFileSync(verified).toString()
+      fs.writeFileSync(verified, content)
+      const output = transpile()
+      assert.ok(output.includes('Skipping') === false)
+    })
   })
   describe('transformation packs', function() {
     this.timeout(0)


### PR DESCRIPTION
## Overview:
Added utility function to skip unnecessary transpilation when source files haven't been modified. This optimization compares file modification timestamps to determine if retranspilation is needed, improving build performance.

## Changes: 
- Added unit tests to verify skip/retranspile behavior
- Implemented timestamp comparison logic
- Handled case when transpiled file doesn't exist

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the transpilation process by introducing a `prepare` function, modifying the `transpile` function to use it, and adding a `needsRetranspile` check to optimize file processing. It also enhances test cases for retranspilation based on file modifications.

### Detailed summary
- Renamed `transpile` function to `prepare`.
- Added a new `transpile` function that calls `prepare`.
- Introduced `retranspile` function to handle cases when files are modified.
- Implemented `needsRetranspile` function to check modification times.
- Updated `transform` function to use `needsRetranspile`.
- Enhanced test cases for verifying retranspilation behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->