### PR TITLE
Fix `i64.gt` to return `bool` (#208)

### DIFF
--- a/eo2js-runtime/src/objects/org/eolang/i64$gt.js
+++ b/eo2js-runtime/src/objects/org/eolang/i64$gt.js
@@ -7,7 +7,6 @@ const {LONG} = require('../../../runtime/types')
 const {LAMBDA, RHO} = require('../../../runtime/attribute/specials')
 const at_void = require('../../../runtime/attribute/at-void')
 const data = require('../../../runtime/data')
-const phi = require('../../../runtime/phi');
 
 /**
  * The i64.gt.
@@ -17,11 +16,9 @@ const i64$gt = function() {
   const obj = object('i64$gt')
   obj.attrs.x = at_void('x')
   obj.assets[LAMBDA] = function(self) {
-    return phi.take('org.eolang.i64').with({
-      0: data.toObject(
-        dataized(self.take(RHO), LONG) > dataized(self.take('x').take('as-i64'), LONG)
-      )
-    })
+    return data.toObject(
+      dataized(self.take(RHO), LONG) > dataized(self.take('x').take('as-i64'), LONG)
+    )
   }
   return obj
 }

--- a/eo2js-runtime/test/objects/org/eolang/i64$gt.test.js
+++ b/eo2js-runtime/test/objects/org/eolang/i64$gt.test.js
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+const assert = require('assert');
+const i64$gt = require('../../../../temp/objects/org/eolang/i64$gt');
+const {BOOL} = require('../../../../temp/runtime/types');
+const dataized = require('../../../../temp/runtime/dataized');
+const {RHO} = require('../../../../temp/runtime/attribute/specials');
+const at_rho = require('../../../../temp/runtime/attribute/at-rho');
+const at_simple = require('../../../../temp/runtime/attribute/at-simple');
+const data = require('../../../../temp/runtime/data');
+const bytesOf = require('../../../../temp/runtime/bytes-of');
+
+/**
+ * Build an i64-like object that holds 8 bytes representing the given BigInt
+ * and exposes itself via the `as-i64` attribute (so it can be reused both as
+ * the ρ of `i64.gt` and as its argument).
+ * @param {bigint} value - Long value
+ * @return {object} - i64-like object
+ */
+const longObject = function(value) {
+  const obj = data.toObject(bytesOf.long(value).asBytes());
+  obj.attrs['as-i64'] = at_simple(obj);
+  return obj;
+};
+
+describe('i64$gt', () => {
+  it('should confirm that 7L > 3L', () => {
+    const gt = i64$gt();
+    gt.attrs[RHO] = at_rho(longObject(7n));
+    assert.equal(
+      dataized(gt.with({'x': longObject(3n)}), BOOL),
+      true
+    );
+  });
+  it('should not confirm that 5L > 10L', () => {
+    const gt = i64$gt();
+    gt.attrs[RHO] = at_rho(longObject(5n));
+    assert.equal(
+      dataized(gt.with({'x': longObject(10n)}), BOOL),
+      false
+    );
+  });
+});


### PR DESCRIPTION
@yegor256 this PR closes #208.

## Problem

`eo2js-runtime/src/objects/org/eolang/i64$gt.js` wrapped its boolean comparison result in `phi.take('org.eolang.i64').with({0: data.toObject(...)})`, with two consequences:

1. **Wrong return type.** `i64.gt` returned an `org.eolang.i64` instead of a `bool`, inconsistent with `number.gt` (which returns `data.toObject(bool)` directly).
2. **Crash in standalone contexts.** `phi.take('org.eolang.i64')` walks `objects/org/eolang/` looking for an `i64` package or `i64.js` file, neither of which exists in the runtime, so any call to `i64.gt` aborted with `Error: Couldn't find object 'i64' from 'org.eolang.i64'`.

## Fix

Mirror `number$gt.js` and return `data.toObject(bool)` directly. The unused `phi` import is dropped.

```js
obj.assets[LAMBDA] = function(self) {
  return data.toObject(
    dataized(self.take(RHO), LONG) > dataized(self.take('x').take('as-i64'), LONG)
  )
}
```

## Tests

Added `eo2js-runtime/test/objects/org/eolang/i64$gt.test.js` covering both branches:

- `7L > 3L` dataizes to `true`
- `5L > 10L` dataizes to `false`

Both tests fail on `master` with `Couldn't find object 'i64' from 'org.eolang.i64'` and pass with this change. The full grunt task (mocha + eslint) is green locally and on CI (16/16 checks). Ready for merge.